### PR TITLE
Fix lcm-gen compatibility issues

### DIFF
--- a/lcm_mon/network.py
+++ b/lcm_mon/network.py
@@ -126,8 +126,8 @@ def load_lcm_modules(folders):
         dest_file = os.path.join(lcm_dir, filename)
         new_lcm_file = shutil.copyfile(lcm_file, dest_file)
         subprocess.call(["lcm-gen", "-p", new_lcm_file,
-            "--ppath", lcm_dir,
-            "--python-no-init"])
+                         "--ppath", lcm_dir])
+    os.system(f"find {lcm_dir} -name '*__init__.py' -delete")
     py_pattern = os.path.join(lcm_dir, "**/*.py")
     py_files = glob.glob(py_pattern, recursive=True)
     lcm_classes = []


### PR DESCRIPTION
Fixes missing message details when lcm_mon is provided with  -t argument and path to the .lcm files/ 

1) **--python-no-init** argument is no longer present in lcm-gen binaries. 
2) Also removing top level **__init__.py** after lcm_gen because it prevents **load_lcm_modules** from loading all the message types